### PR TITLE
Fix EA definition lookup fields

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,6 @@
+### 1.0.36 - 2026.01.26
+- Fix EA definition lookup on grids where `allow_multiple` is not a readable field (avoid 400 on `extensibleattributedef`)
+
 ### 1.0.32 - 2026.01.26
 - Auto-resolve list/enum Extensible Attribute display values to internal IDs (single and multi-value)
 - Shared EA conversion helper for consistent behavior across network and DHCP cmdlets

--- a/PowerInfoblox.psd1
+++ b/PowerInfoblox.psd1
@@ -8,7 +8,7 @@
     Description          = 'Helper module for Infoblox.'
     FunctionsToExport    = @('Add-InfobloxDHCPRange', 'Add-InfobloxDHCPRangeOptions', 'Add-InfobloxDHCPReservation', 'Add-InfoBloxDNSRecord', 'Add-InfobloxFixedAddress', 'Add-InfobloxNetwork', 'Add-InfobloxNetworkExtensibleAttribute', 'Connect-Infoblox', 'Disconnect-Infoblox', 'Get-InfobloxDHCPLease', 'Get-InfobloxDHCPRange', 'Get-InfobloxDiscoveryTask', 'Get-InfobloxDNSAuthZone', 'Get-InfobloxDNSDelegatedZone', 'Get-InfobloxDNSForwardZone', 'Get-InfobloxDNSRecord', 'Get-InfobloxDNSRecordAll', 'Get-InfobloxDNSView', 'Get-InfobloxFixedAddress', 'Get-InfobloxGrid', 'Get-InfobloxIPAddress', 'Get-InfobloxMember', 'Get-InfobloxNetwork', 'Get-InfobloxNetworkContainer', 'Get-InfobloxNetworkNextAvailableIP', 'Get-InfobloxNetworkNextAvailableNetwork', 'Get-InfobloxNetworkView', 'Get-InfobloxObjects', 'Get-InfobloxPermission', 'Get-InfobloxResponsePolicyZones', 'Get-InfobloxSchema', 'Get-InfoBloxSearch', 'Get-InfobloxVDiscoveryTask', 'Invoke-InfobloxQuery', 'New-InfobloxOption', 'Remove-InfobloxDHCPRangeOptions', 'Remove-InfobloxDnsRecord', 'Remove-InfobloxFixedAddress', 'Remove-InfobloxIPAddress', 'Remove-InfobloxNetworkExtensibleAttribute', 'Remove-InfobloxObject', 'Set-InfobloxDHCPRange', 'Set-InfobloxDHCPRangeOptions', 'Set-InfobloxDNSRecord', 'Set-InfobloxNetworkMembers')
     GUID                 = '9fc9fd61-7f11-4f4b-a527-084086f1905f'
-    ModuleVersion        = '1.0.35'
+    ModuleVersion        = '1.0.36'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Private/Get-InfobloxExtensibleAttributeDefinition.ps1
+++ b/Private/Get-InfobloxExtensibleAttributeDefinition.ps1
@@ -21,10 +21,15 @@ function Get-InfobloxExtensibleAttributeDefinition {
 
     $QueryParameter = @{
         name           = $Name
-        _return_fields = 'name,type,list_values,allow_multiple'
+        _return_fields = 'name,type,list_values'
     }
 
     $Result = Invoke-InfobloxQuery -RelativeUri "extensibleattributedef" -Method 'GET' -QueryParameter $QueryParameter -WhatIf:$false
+    if (-not $Result) {
+        # As a last resort, let the API decide default fields.
+        $QueryParameter.Remove('_return_fields')
+        $Result = Invoke-InfobloxQuery -RelativeUri "extensibleattributedef" -Method 'GET' -QueryParameter $QueryParameter -WhatIf:$false
+    }
     if ($Result -is [array]) {
         $Result = $Result | Select-Object -First 1
     }


### PR DESCRIPTION
## Summary\n- remove allow_multiple from extensibleattributedef _return_fields\n- keep fallback to default fields for EA definition lookup\n- bump version to 1.0.36\n\n## Testing\n- pwsh -NoProfile -File .\\PowerInfoblox.Tests.ps1