### PR TITLE
Fix schema fetching and add configurable request timeouts

### DIFF
--- a/.github/workflows/test-powershell-module.yml
+++ b/.github/workflows/test-powershell-module.yml
@@ -28,10 +28,8 @@ jobs:
 
       - name: Refresh module manifest
         shell: pwsh
-        env:
-          RefreshPSD1Only: 'true'
         run: |
-          ./Build/Build-Module.ps1
+          ./Build/Build-Module.ps1 -ConfigurationGateMode Manifest
 
       - name: Upload refreshed manifest
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-powershell-module.yml
+++ b/.github/workflows/test-powershell-module.yml
@@ -133,9 +133,6 @@ jobs:
           name: psd1
           path: .
 
-      - name: Install PowerShell
-        run: brew install --cask powershell
-
       - name: Install PowerShell modules
         shell: pwsh
         run: |

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,4 +1,11 @@
-Import-Module PSPublishModule -Force #-RequiredVersion '2.0.26'
+param(
+    [ValidateSet('Manifest', 'Build', 'Publish')]
+    [string] $ConfigurationGateMode = 'Build',
+
+    [bool] $SignModule = $true
+)
+
+Import-Module PSPublishModule -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'PowerInfoblox' {
     # Usual defaults as per standard module
@@ -82,14 +89,14 @@ Build-Module -ModuleName 'PowerInfoblox' {
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
 
     New-ConfigurationImportModule -ImportSelf -ImportRequiredModules
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = $true
-        CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+        SignModule                        = $SignModule
+        CertificateThumbprint             = '92E95FB58EFFA6A4A75E77A33CDD6BFE6DD30F1A'
         DeleteTargetModuleBeforeBuild     = $true
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
@@ -106,16 +113,9 @@ Build-Module -ModuleName 'PowerInfoblox' {
 
     } -CopyFilesRelative -IncludeTagName
 
-    $newConfigurationArtefactSplat = @{
-        Type                = 'Script'
-        Enable              = $true
-        Path                = "$PSScriptRoot\..\Artefacts\Script"
-        ScriptName          = 'InfoBloxTest.ps1'
-        PostScriptMergePath = "$PSScriptRoot\..\Examples\Package\ExampleProd.ps1"
-    }
-    New-ConfigurationArtefact @newConfigurationArtefactSplat
-
     # global options for publishing to github/psgallery
     #New-ConfigurationPublish -Type PowerShellGallery -FilePath 'C:\Support\Important\PowerShellGalleryAPI.txt' -Enabled:$true
     #New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$true
-}
+
+    New-ConfigurationGate -Mode $ConfigurationGateMode
+} -ExitCode

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+### 1.0.37 - 2026.07.16
+- Use the valueless `_schema` option required by stricter Infoblox NIOS releases
+- Add configurable request timeouts through `Connect-Infoblox` and `Invoke-InfobloxQuery`
+
 ### 1.0.36 - 2026.01.26
 - Fix EA definition lookup on grids where `allow_multiple` is not a readable field (avoid 400 on `extensibleattributedef`)
 

--- a/Private/Get-FieldsFromSchema.ps1
+++ b/Private/Get-FieldsFromSchema.ps1
@@ -22,7 +22,7 @@
             $Script:InfobloxSchemaFields[$SchemaObject] = ($FilteredFields -join ',')
             $Script:InfobloxSchemaFields[$SchemaObject]
         } else {
-            Write-Warning -Message "Get-FieldsFromSchema - Failed to fetch schema for record type 'allrecords'. Using defaults"
+            Write-Warning -Message "Get-FieldsFromSchema - Failed to fetch schema for record type '$SchemaObject'. Using defaults"
         }
     }
 }

--- a/Public/Connect-Infoblox.ps1
+++ b/Public/Connect-Infoblox.ps1
@@ -1,4 +1,47 @@
 ﻿function Connect-Infoblox {
+    <#
+    .SYNOPSIS
+    Configures a connection to an Infoblox WAPI endpoint.
+
+    .DESCRIPTION
+    Stores the server, authentication, API version, web session, and request timeout used by PowerInfoblox commands.
+
+    .PARAMETER Server
+    The Infoblox server name or IP address.
+
+    .PARAMETER Username
+    The user name used with an encrypted password.
+
+    .PARAMETER EncryptedPassword
+    A string created from a secure string for the specified user name.
+
+    .PARAMETER Credential
+    The credential used to authenticate to Infoblox.
+
+    .PARAMETER ApiVersion
+    The WAPI version used to build the base URI.
+
+    .PARAMETER EnableTLS12
+    Enables TLS 1.2 for the current PowerShell process.
+
+    .PARAMETER AllowSelfSignedCerts
+    Allows self-signed server certificates.
+
+    .PARAMETER SkipInitialConnection
+    Skips the initial schema request that verifies the connection.
+
+    .PARAMETER TimeoutSec
+    The request timeout in seconds. The default is 600 seconds.
+
+    .PARAMETER ReturnObject
+    Returns the stored connection configuration.
+
+    .EXAMPLE
+    Connect-Infoblox -Server 'grid.example.com' -Credential $Credential
+
+    .EXAMPLE
+    Connect-Infoblox -Server 'grid.example.com' -Credential $Credential -TimeoutSec 3600
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, ParameterSetName = 'UserName')]
@@ -22,6 +65,8 @@
         [Parameter(ParameterSetName = 'UserName')]
         [Parameter(ParameterSetName = 'Credential')]
         [switch] $SkipInitialConnection,
+        [ValidateRange(1, 2147483647)]
+        [int] $TimeoutSec = 600,
         [switch] $ReturnObject
     )
 
@@ -49,6 +94,7 @@
     $PSDefaultParameterValues['Invoke-InfobloxQuery:Server'] = $Server
     $PSDefaultParameterValues['Invoke-InfobloxQuery:BaseUri'] = "https://$Server/wapi/v$apiVersion"
     $PSDefaultParameterValues['Invoke-InfobloxQuery:WebSession'] = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+    $PSDefaultParameterValues['Invoke-InfobloxQuery:TimeoutSec'] = $TimeoutSec
 
     # The infoblox configuration is not really used anywhere. It's just a placeholder
     # It's basecause we use $PSDefaultParameterValues to pass the parameters to Invoke-InfobloxQuery
@@ -57,6 +103,7 @@
         ApiVersion = $ApiVersion
         Server     = $Server
         BaseUri    = "https://$Server/wapi/v$apiVersion"
+        TimeoutSec = $TimeoutSec
     }
 
     if ($AllowSelfSignedCerts) {

--- a/Public/Disconnect-Infoblox.ps1
+++ b/Public/Disconnect-Infoblox.ps1
@@ -31,4 +31,5 @@
     $PSDefaultParameterValues.Remove('Invoke-InfobloxQuery:Server')
     $PSDefaultParameterValues.Remove('Invoke-InfobloxQuery:BaseUri')
     $PSDefaultParameterValues.Remove('Invoke-InfobloxQuery:WebSession')
+    $PSDefaultParameterValues.Remove('Invoke-InfobloxQuery:TimeoutSec')
 }

--- a/Public/Get-InfobloxSchema.ps1
+++ b/Public/Get-InfobloxSchema.ps1
@@ -43,11 +43,8 @@
     }
     if ($Object) {
         $invokeInfobloxQuerySplat = @{
-            RelativeUri = "$($Object.ToLower())"
+            RelativeUri = "$($Object.ToLower())?_schema"
             Method      = 'Get'
-            Query       = @{
-                _schema = $true
-            }
         }
     } else {
         $invokeInfobloxQuerySplat = @{

--- a/Public/Invoke-InfobloxQuery.ps1
+++ b/Public/Invoke-InfobloxQuery.ps1
@@ -1,4 +1,41 @@
 ﻿function Invoke-InfobloxQuery {
+    <#
+    .SYNOPSIS
+    Sends a request to an Infoblox WAPI endpoint.
+
+    .DESCRIPTION
+    Builds an Infoblox WAPI URI, sends the request, and returns the deserialized response.
+
+    .PARAMETER BaseUri
+    The WAPI base URI.
+
+    .PARAMETER RelativeUri
+    The object path or URI relative to the WAPI base URI.
+
+    .PARAMETER Credential
+    The credential used to authenticate to Infoblox.
+
+    .PARAMETER WebSession
+    The web request session used for cookie-based authentication.
+
+    .PARAMETER QueryParameter
+    Query parameters appended to the request URI.
+
+    .PARAMETER Method
+    The HTTP method. The default is GET.
+
+    .PARAMETER Body
+    The request body, serialized as JSON.
+
+    .PARAMETER TimeoutSec
+    The request timeout in seconds. The default is 600 seconds.
+
+    .EXAMPLE
+    Invoke-InfobloxQuery -BaseUri 'https://grid.example.com/wapi/v2.13.8' -RelativeUri 'network' -Credential $Credential
+
+    .EXAMPLE
+    Invoke-InfobloxQuery -BaseUri 'https://grid.example.com/wapi/v2.13.8' -RelativeUri 'network' -Credential $Credential -TimeoutSec 30
+    #>
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [parameter(Mandatory)][string] $BaseUri,
@@ -7,7 +44,8 @@
         [Parameter()][Microsoft.PowerShell.Commands.WebRequestSession] $WebSession,
         [parameter()][System.Collections.IDictionary] $QueryParameter,
         [parameter()][string] $Method = 'GET',
-        [parameter()][System.Collections.IDictionary] $Body
+        [parameter()][System.Collections.IDictionary] $Body,
+        [parameter()][ValidateRange(1, 2147483647)][int] $TimeoutSec = 600
     )
 
     if (-not $Script:InfobloxConfiguration) {
@@ -50,7 +88,7 @@
                 ErrorAction = 'Stop'
                 Verbose     = $false
                 WebSession  = $WebSession
-                TimeoutSec  = 600
+                TimeoutSec  = $TimeoutSec
             }
             if ($Body) {
                 $invokeRestMethodSplat.Body = $JSONBody

--- a/README.MD
+++ b/README.MD
@@ -97,6 +97,12 @@ Connect to Infoblox using your credentials.
 Connect-Infoblox -Server 'ipam.example.com' -ApiVersion '2.12' -EnableTLS12 -Credential (Get-Credential)
 ```
 
+Set a longer timeout for environments with long-running WAPI requests. The default is 600 seconds.
+
+```powershell
+Connect-Infoblox -Server 'ipam.example.com' -ApiVersion '2.13.8' -Credential (Get-Credential) -TimeoutSec 3600
+```
+
 ```powershell
 $Username = '<your username>'
 # Encrypted password

--- a/Tests/SchemaAndConnection.Tests.ps1
+++ b/Tests/SchemaAndConnection.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'Infoblox schema requests' {
         It 'uses the valueless schema option for object schema requests' {
             $null = Get-InfobloxSchema -Object 'NetworkContainer'
 
-            Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter {
+            Should -Invoke -CommandName Invoke-RestMethod -Times 1 -ParameterFilter {
                 $Uri -eq 'https://example.test/wapi/v2.13.8/networkcontainer?_schema'
             }
         }
@@ -42,7 +42,7 @@ Describe 'Infoblox schema requests' {
 
             $null = Get-FieldsFromSchema -SchemaObject 'networkcontainer'
 
-            Assert-MockCalled Write-Warning -Times 1 -ParameterFilter {
+            Should -Invoke -CommandName Write-Warning -Times 1 -ParameterFilter {
                 $Message -eq "Get-FieldsFromSchema - Failed to fetch schema for record type 'networkcontainer'. Using defaults"
             }
         }
@@ -77,7 +77,7 @@ Describe 'Infoblox request timeout' {
 
             $null = Invoke-InfobloxQuery -RelativeUri 'network'
 
-            Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter { $TimeoutSec -eq 600 }
+            Should -Invoke -CommandName Invoke-RestMethod -Times 1 -ParameterFilter { $TimeoutSec -eq 600 }
         }
 
         It 'uses the timeout configured by Connect-Infoblox' {
@@ -86,7 +86,7 @@ Describe 'Infoblox request timeout' {
             $null = Invoke-InfobloxQuery -RelativeUri 'network'
 
             $connection.TimeoutSec | Should -Be 3600
-            Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter { $TimeoutSec -eq 3600 }
+            Should -Invoke -CommandName Invoke-RestMethod -Times 1 -ParameterFilter { $TimeoutSec -eq 3600 }
         }
 
         It 'allows a request to override the connection timeout' {
@@ -94,7 +94,7 @@ Describe 'Infoblox request timeout' {
 
             $null = Invoke-InfobloxQuery -RelativeUri 'network' -TimeoutSec 30
 
-            Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter { $TimeoutSec -eq 30 }
+            Should -Invoke -CommandName Invoke-RestMethod -Times 1 -ParameterFilter { $TimeoutSec -eq 30 }
         }
 
         It 'clears the configured timeout when disconnecting' {

--- a/Tests/SchemaAndConnection.Tests.ps1
+++ b/Tests/SchemaAndConnection.Tests.ps1
@@ -1,0 +1,108 @@
+Describe 'Infoblox schema requests' {
+    InModuleScope PowerInfoblox {
+        BeforeAll {
+            $script:previousDefaults = @{}
+            foreach ($Key in $PSDefaultParameterValues.Keys) {
+                $script:previousDefaults[$Key] = $PSDefaultParameterValues[$Key]
+            }
+        }
+
+        BeforeEach {
+            $Script:InfobloxConfiguration = @{ BaseUri = 'https://example.test/wapi/v2.13.8' }
+            $PSDefaultParameterValues['Invoke-InfobloxQuery:BaseUri'] = 'https://example.test/wapi/v2.13.8'
+            $PSDefaultParameterValues['Invoke-InfobloxQuery:Credential'] = [pscredential]::new('user', (ConvertTo-SecureString 'pass' -AsPlainText -Force))
+            $PSDefaultParameterValues['Invoke-InfobloxQuery:WebSession'] = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            Mock Invoke-RestMethod -MockWith {
+                [pscustomobject]@{
+                    fields = @()
+                    type   = 'networkcontainer'
+                }
+            }
+        }
+
+        AfterAll {
+            $Script:InfobloxConfiguration = $null
+            $PSDefaultParameterValues.Clear()
+            foreach ($Key in $script:previousDefaults.Keys) {
+                $PSDefaultParameterValues[$Key] = $script:previousDefaults[$Key]
+            }
+        }
+
+        It 'uses the valueless schema option for object schema requests' {
+            $null = Get-InfobloxSchema -Object 'NetworkContainer'
+
+            Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter {
+                $Uri -eq 'https://example.test/wapi/v2.13.8/networkcontainer?_schema'
+            }
+        }
+
+        It 'reports the object type when schema retrieval fails' {
+            Mock Get-InfobloxSchema
+            Mock Write-Warning
+
+            $null = Get-FieldsFromSchema -SchemaObject 'networkcontainer'
+
+            Assert-MockCalled Write-Warning -Times 1 -ParameterFilter {
+                $Message -eq "Get-FieldsFromSchema - Failed to fetch schema for record type 'networkcontainer'. Using defaults"
+            }
+        }
+    }
+}
+
+Describe 'Infoblox request timeout' {
+    InModuleScope PowerInfoblox {
+        BeforeAll {
+            $script:previousDefaults = @{}
+            foreach ($Key in $PSDefaultParameterValues.Keys) {
+                $script:previousDefaults[$Key] = $PSDefaultParameterValues[$Key]
+            }
+            $script:testCredential = [pscredential]::new('user', (ConvertTo-SecureString 'pass' -AsPlainText -Force))
+        }
+
+        BeforeEach {
+            Disconnect-Infoblox
+            Mock Invoke-RestMethod -MockWith { [pscustomobject]@{ ok = $true } }
+        }
+
+        AfterAll {
+            Disconnect-Infoblox
+            $PSDefaultParameterValues.Clear()
+            foreach ($Key in $script:previousDefaults.Keys) {
+                $PSDefaultParameterValues[$Key] = $script:previousDefaults[$Key]
+            }
+        }
+
+        It 'uses 600 seconds by default' {
+            Connect-Infoblox -Server 'example.test' -Credential $script:testCredential -SkipInitialConnection
+
+            $null = Invoke-InfobloxQuery -RelativeUri 'network'
+
+            Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter { $TimeoutSec -eq 600 }
+        }
+
+        It 'uses the timeout configured by Connect-Infoblox' {
+            $connection = Connect-Infoblox -Server 'example.test' -Credential $script:testCredential -TimeoutSec 3600 -SkipInitialConnection -ReturnObject
+
+            $null = Invoke-InfobloxQuery -RelativeUri 'network'
+
+            $connection.TimeoutSec | Should -Be 3600
+            Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter { $TimeoutSec -eq 3600 }
+        }
+
+        It 'allows a request to override the connection timeout' {
+            Connect-Infoblox -Server 'example.test' -Credential $script:testCredential -TimeoutSec 3600 -SkipInitialConnection
+
+            $null = Invoke-InfobloxQuery -RelativeUri 'network' -TimeoutSec 30
+
+            Assert-MockCalled Invoke-RestMethod -Times 1 -ParameterFilter { $TimeoutSec -eq 30 }
+        }
+
+        It 'clears the configured timeout when disconnecting' {
+            Connect-Infoblox -Server 'example.test' -Credential $script:testCredential -TimeoutSec 3600 -SkipInitialConnection
+
+            Disconnect-Infoblox
+
+            $PSDefaultParameterValues.ContainsKey('Invoke-InfobloxQuery:TimeoutSec') | Should -BeFalse
+        }
+    }
+}

--- a/Tests/Set-InfobloxNetworkMembers.Tests.ps1
+++ b/Tests/Set-InfobloxNetworkMembers.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Set-InfobloxNetworkMembers' {
         It 'returns warning when no members inputs are provided' {
             Mock Write-Warning {}
             Set-InfobloxNetworkMembers -Network '10.46.5.128/25'
-            Assert-MockCalled Write-Warning -Times 1
+            Should -Invoke -CommandName Write-Warning -Times 1
         }
 
         It 'builds members payload from Network with defaults' {
@@ -32,7 +32,7 @@ Describe 'Set-InfobloxNetworkMembers' {
 
             Set-InfobloxNetworkMembers -Network '10.46.5.128/25' -Members @('b', 'c') | Out-Null
 
-            Assert-MockCalled Invoke-InfobloxQuery -ParameterFilter { $Method -eq 'PUT' } -Times 1
+            Should -Invoke -CommandName Invoke-InfobloxQuery -ParameterFilter { $Method -eq 'PUT' } -Times 1
             $script:putBody.members | Should -HaveCount 2
             $script:putBody.members[0]._struct | Should -Be 'msdhcpserver'
             $script:putBody.members[0].ipv4addr | Should -Be 'b'


### PR DESCRIPTION
## Summary

- send object schema requests with the valueless `?_schema` option accepted by stricter Infoblox NIOS releases
- add `TimeoutSec` to `Connect-Infoblox` and `Invoke-InfobloxQuery`, retaining the 600-second default while allowing connection-wide and per-request overrides
- clear the configured timeout on disconnect and report the actual object type when schema fallback is needed
- document the new connection option and add regression coverage for URI construction, timeout propagation, overrides, and cleanup
- align the manifest CI lane and build wrapper with the current PSPublishModule configuration model, remove a dead script-artifact reference, and use the renewed signing certificate
- modernize mock assertions for Pester 5/6 and use the PowerShell installation already provided by GitHub's macOS runner

## Validation

- local PowerShell 7.6.3 with Pester 5.7.1 and 6.0.0: 20 passed in each run
- local Windows PowerShell 5.1 with Pester 5.8.0 and 6.0.0: 20 passed in each run
- all changed PowerShell files parse successfully
- `Build/Build-Module.ps1 -ConfigurationGateMode Manifest` completed successfully
- GitHub Actions at `5653bf7`: manifest refresh plus Windows PowerShell 5.1, Windows PowerShell 7, Ubuntu PowerShell 7, and macOS PowerShell 7 all passed

## Release-path validation

- public PSPublishModule 3.0.66 completed the full unsigned Build gate and produced packed and unpacked artifacts
- generated PowerInfoblox 1.0.37.1 parsed and imported under PowerShell 7 and Windows PowerShell 5.1
- embedded C# `using` statements remained inside the `Add-Type` here-string, and `TrustAllCertsPolicy` compiled successfully on Windows PowerShell 5.1