### PR TITLE
Improve DHCP range DDNS controls

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,8 @@
+### 1.0.38 - 2026.07.29
+- Add explicit inherit/override and enabled/disabled controls for DHCP range DDNS updates
+- Keep the existing `AlwaysUpdateDns` policy separate from DDNS enablement
+- Clear or omit empty DHCP range comments instead of storing Boolean false as text
+
 ### 1.0.37 - 2026.07.16
 - Use the valueless `_schema` option required by stricter Infoblox NIOS releases
 - Add configurable request timeouts through `Connect-Infoblox` and `Invoke-InfobloxQuery`

--- a/Private/ConvertTo-InfobloxComment.ps1
+++ b/Private/ConvertTo-InfobloxComment.ps1
@@ -1,0 +1,19 @@
+function ConvertTo-InfobloxComment {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [object] $Comment
+    )
+
+    if ($null -eq $Comment) {
+        return ''
+    }
+    if (($Comment -is [bool] -or $Comment -is [System.Management.Automation.SwitchParameter]) -and -not [bool] $Comment) {
+        return ''
+    }
+    $CommentText = [string] $Comment
+    if ([string]::IsNullOrWhiteSpace($CommentText)) {
+        return ''
+    }
+    $CommentText
+}

--- a/Private/ConvertTo-InfobloxDHCPRangeDDNSSetting.ps1
+++ b/Private/ConvertTo-InfobloxDHCPRangeDDNSSetting.ps1
@@ -1,0 +1,22 @@
+function ConvertTo-InfobloxDHCPRangeDDNSSetting {
+    [CmdletBinding()]
+    param(
+        [ValidateSet('Inherit', 'Override')]
+        [string] $DDNSUpdateMode,
+
+        [Nullable[bool]] $DDNSEnabled
+    )
+
+    $Setting = [ordered] @{}
+    if ($DDNSUpdateMode) {
+        $Setting['use_enable_ddns'] = $DDNSUpdateMode -eq 'Override'
+    }
+    if ($null -ne $DDNSEnabled) {
+        if ($DDNSUpdateMode -eq 'Inherit') {
+            throw 'DDNSEnabled cannot be set when DDNSUpdateMode is Inherit.'
+        }
+        $Setting['use_enable_ddns'] = $true
+        $Setting['enable_ddns'] = [bool] $DDNSEnabled
+    }
+    $Setting
+}

--- a/Public/Add-InfobloxDHCPRange.ps1
+++ b/Public/Add-InfobloxDHCPRange.ps1
@@ -16,7 +16,7 @@
     The name of the DHCP range.
 
     .PARAMETER Comment
-    A comment for the DHCP range.
+    A comment for the DHCP range. Null, blank, and Boolean false values are treated as no comment.
 
     .PARAMETER NetworkView
     The network view in which the DHCP range will be added. The default is 'default'.
@@ -46,7 +46,13 @@
     An array of IP addresses or IP address ranges to be excluded from the DHCP range.
 
     .PARAMETER AlwaysUpdateDns
-    If this switch is present, DNS will always be updated for the DHCP range.
+    Controls whether the DHCP server always updates DNS when DDNS is enabled. This setting does not enable DDNS.
+
+    .PARAMETER DDNSUpdateMode
+    Controls whether the range inherits the DDNS enablement setting or overrides it locally.
+
+    .PARAMETER DDNSEnabled
+    Enables or disables DDNS on the range. Supplying this value automatically selects local override mode.
 
     .PARAMETER Disable
     If this switch is present, the DHCP range will be disabled.
@@ -70,6 +76,10 @@
     }
 
     Add-InfobloxDHCPRange @addInfobloxDHCPRangeSplat
+
+    .EXAMPLE
+    Add-InfobloxDHCPRange -StartAddress '10.22.41.100' -EndAddress '10.22.41.150' -DDNSUpdateMode Override -DDNSEnabled $false
+    Adds a DHCP range that overrides the inherited DDNS setting and disables DDNS updates.
 
     .EXAMPLE
     $addInfobloxDHCPRangeSplat = @{
@@ -109,7 +119,7 @@
         [Parameter(Mandatory)][string] $StartAddress,
         [Parameter(Mandatory)][string] $EndAddress,
         [string] $Name,
-        [string] $Comment,
+        [AllowNull()][object] $Comment,
         [string] $NetworkView = 'default',
         [string] $MSServer,
         [switch] $ReturnOutput,
@@ -120,6 +130,8 @@
         [ValidateSet('MEMBER', 'MS_FAILOVER', 'NONE', 'MS_SERVER', 'FAILOVER')] [string] $ServerAssociationType,
         [Array] $Exclude,
         [switch] $AlwaysUpdateDns,
+        [ValidateSet('Inherit', 'Override')][string] $DDNSUpdateMode,
+        [Nullable[bool]] $DDNSEnabled,
         [switch] $Disable
     )
     if (-not $Script:InfobloxConfiguration) {
@@ -138,8 +150,11 @@
     if ($Name) {
         $Body["name"] = $Name
     }
-    if ($Comment) {
-        $Body["comment"] = $Comment
+    if ($PSBoundParameters.ContainsKey('Comment')) {
+        $NormalizedComment = ConvertTo-InfobloxComment -Comment $Comment
+        if ($NormalizedComment) {
+            $Body["comment"] = $NormalizedComment
+        }
     }
     if ($ServerAssociationType) {
         $Body["server_association_type"] = $ServerAssociationType
@@ -199,6 +214,17 @@
 
     if ($PSBoundParameters.ContainsKey('AlwaysUpdateDns')) {
         $Body["always_update_dns"] = $AlwaysUpdateDns.IsPresent
+    }
+    $convertToInfobloxDHCPRangeDDNSSettingSplat = @{}
+    if ($PSBoundParameters.ContainsKey('DDNSUpdateMode')) {
+        $convertToInfobloxDHCPRangeDDNSSettingSplat['DDNSUpdateMode'] = $DDNSUpdateMode
+    }
+    if ($PSBoundParameters.ContainsKey('DDNSEnabled')) {
+        $convertToInfobloxDHCPRangeDDNSSettingSplat['DDNSEnabled'] = $DDNSEnabled
+    }
+    $DDNSSetting = ConvertTo-InfobloxDHCPRangeDDNSSetting @convertToInfobloxDHCPRangeDDNSSettingSplat
+    foreach ($Key in $DDNSSetting.Keys) {
+        $Body[$Key] = $DDNSSetting[$Key]
     }
     if ($PSBoundParameters.ContainsKey('Disable')) {
         $Body["disable"] = $Disable.IsPresent

--- a/Public/Set-InfobloxDHCPRange.ps1
+++ b/Public/Set-InfobloxDHCPRange.ps1
@@ -10,7 +10,7 @@
     The unique identifier for the DHCP range to be modified.
 
     .PARAMETER Comment
-    A comment to associate with the DHCP range.
+    A comment to associate with the DHCP range. Pass an empty, null, or Boolean false value to clear the comment.
 
     .PARAMETER MSServer
     The Microsoft DHCP server associated with the range.
@@ -34,13 +34,27 @@
     An array of IP addresses or address ranges to exclude from the DHCP range.
 
     .PARAMETER AlwaysUpdateDns
-    Indicates whether to always update DNS.
+    Controls whether the DHCP server always updates DNS when DDNS is enabled. This setting does not enable DDNS.
+
+    .PARAMETER DDNSUpdateMode
+    Controls whether the range inherits the DDNS enablement setting or overrides it locally.
+
+    .PARAMETER DDNSEnabled
+    Enables or disables DDNS on the range. Supplying this value automatically selects local override mode.
 
     .PARAMETER Disable
     Indicates whether to disable the DHCP range.
 
     .EXAMPLE
     Set-InfobloxDHCPRange -ReferenceID 'DHCPRange-1' -Comment 'This is a DHCP range.'
+
+    .EXAMPLE
+    Set-InfobloxDHCPRange -ReferenceID 'DHCPRange-1' -DDNSUpdateMode Override -DDNSEnabled $false
+    Overrides the inherited DDNS setting and disables DDNS updates for the range.
+
+    .EXAMPLE
+    Set-InfobloxDHCPRange -ReferenceID 'DHCPRange-1' -DDNSUpdateMode Inherit
+    Restores the inherited DDNS enablement setting for the range.
 
     .EXAMPLE
     Set-InfobloxDHCPRange -ReferenceID 'DHCPRange-1' -Options @(
@@ -56,7 +70,7 @@
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [parameter(ParameterSetName = 'ReferenceID', Mandatory)][string] $ReferenceID,
-        [string] $Comment,
+        [AllowNull()][object] $Comment,
         [string] $MSServer,
         [Alias('ExtensibleAttribute')][System.Collections.IDictionary] $ExtensinbleAttribute,
         [Array] $Options,
@@ -65,6 +79,8 @@
         [ValidateSet('MEMBER', 'MS_FAILOVER', 'NONE', 'MS_SERVER', 'FAILOVER')] [string] $ServerAssociationType,
         [Array] $Exclude,
         [switch] $AlwaysUpdateDns,
+        [ValidateSet('Inherit', 'Override')][string] $DDNSUpdateMode,
+        [Nullable[bool]] $DDNSEnabled,
         [switch] $Disable
     )
 
@@ -77,8 +93,8 @@
     }
 
     $Body = [ordered] @{}
-    if ($Comment) {
-        $Body["comment"] = $Comment
+    if ($PSBoundParameters.ContainsKey('Comment')) {
+        $Body["comment"] = ConvertTo-InfobloxComment -Comment $Comment
     }
     if ($ServerAssociationType) {
         $Body["server_association_type"] = $ServerAssociationType
@@ -135,6 +151,17 @@
     }
     if ($PSBoundParameters.ContainsKey('AlwaysUpdateDns')) {
         $Body["always_update_dns"] = $AlwaysUpdateDns.IsPresent
+    }
+    $convertToInfobloxDHCPRangeDDNSSettingSplat = @{}
+    if ($PSBoundParameters.ContainsKey('DDNSUpdateMode')) {
+        $convertToInfobloxDHCPRangeDDNSSettingSplat['DDNSUpdateMode'] = $DDNSUpdateMode
+    }
+    if ($PSBoundParameters.ContainsKey('DDNSEnabled')) {
+        $convertToInfobloxDHCPRangeDDNSSettingSplat['DDNSEnabled'] = $DDNSEnabled
+    }
+    $DDNSSetting = ConvertTo-InfobloxDHCPRangeDDNSSetting @convertToInfobloxDHCPRangeDDNSSettingSplat
+    foreach ($Key in $DDNSSetting.Keys) {
+        $Body[$Key] = $DDNSSetting[$Key]
     }
     if ($PSBoundParameters.ContainsKey('Disable')) {
         $Body["disable"] = $Disable.IsPresent

--- a/Tests/DHCPRange.Tests.ps1
+++ b/Tests/DHCPRange.Tests.ps1
@@ -1,0 +1,93 @@
+Describe 'DHCP range mutations' {
+    InModuleScope PowerInfoblox {
+        BeforeEach {
+            $Script:InfobloxConfiguration = @{ BaseUri = 'https://example.test/wapi/v2.13.8' }
+            $PSDefaultParameterValues['Invoke-InfobloxQuery:BaseUri'] = 'https://example.test/wapi/v2.13.8'
+            $script:requestBody = $null
+            $script:requestMethod = $null
+            $script:requestUri = $null
+            Mock Invoke-InfobloxQuery -MockWith {
+                $script:requestBody = $Body
+                $script:requestMethod = $Method
+                $script:requestUri = $RelativeUri
+                'range/reference'
+            }
+        }
+
+        AfterAll {
+            $Script:InfobloxConfiguration = $null
+            $PSDefaultParameterValues.Remove('Invoke-InfobloxQuery:BaseUri')
+        }
+
+        It 'clears a range comment instead of serializing Boolean false as text' {
+            Set-InfobloxDHCPRange -ReferenceID 'range/reference' -Comment $false
+
+            $script:requestMethod | Should -Be 'PUT'
+            $script:requestUri | Should -Be 'range/reference'
+            $script:requestBody.Contains('comment') | Should -BeTrue
+            $script:requestBody.comment | Should -Be ''
+        }
+
+        It 'omits a Boolean false comment when creating a range' {
+            Add-InfobloxDHCPRange -StartAddress '10.0.0.10' -EndAddress '10.0.0.20' -Comment $false
+
+            $script:requestMethod | Should -Be 'POST'
+            $script:requestUri | Should -Be 'range'
+            $script:requestBody.Contains('comment') | Should -BeFalse
+        }
+
+        It 'preserves PowerShell string coercion for other comment values' {
+            Set-InfobloxDHCPRange -ReferenceID 'range/reference' -Comment 12345
+
+            $script:requestBody.comment | Should -Be '12345'
+        }
+
+        It 'maps override and disabled DDNS settings to the WAPI fields' {
+            Set-InfobloxDHCPRange -ReferenceID 'range/reference' -DDNSUpdateMode Override -DDNSEnabled $false
+
+            $script:requestBody.use_enable_ddns | Should -BeTrue
+            $script:requestBody.enable_ddns | Should -BeFalse
+        }
+
+        It 'maps inheritance to the DDNS use flag without changing the stored local value' {
+            Set-InfobloxDHCPRange -ReferenceID 'range/reference' -DDNSUpdateMode Inherit
+
+            $script:requestBody.use_enable_ddns | Should -BeFalse
+            $script:requestBody.Contains('enable_ddns') | Should -BeFalse
+        }
+
+        It 'selects override mode when DDNS enablement is supplied directly' {
+            Add-InfobloxDHCPRange -StartAddress '10.0.0.10' -EndAddress '10.0.0.20' -DDNSEnabled $true
+
+            $script:requestBody.use_enable_ddns | Should -BeTrue
+            $script:requestBody.enable_ddns | Should -BeTrue
+        }
+
+        It 'rejects a local DDNS value while inheritance is selected' {
+            {
+                Set-InfobloxDHCPRange -ReferenceID 'range/reference' -DDNSUpdateMode Inherit -DDNSEnabled $false
+            } | Should -Throw '*DDNSEnabled cannot be set*'
+
+            Should -Invoke -CommandName Invoke-InfobloxQuery -Times 0
+        }
+
+        It 'keeps AlwaysUpdateDns separate from DDNS enablement' {
+            Set-InfobloxDHCPRange -ReferenceID 'range/reference' -AlwaysUpdateDns
+
+            $script:requestBody.always_update_dns | Should -BeTrue
+            $script:requestBody.Contains('enable_ddns') | Should -BeFalse
+            $script:requestBody.Contains('use_enable_ddns') | Should -BeFalse
+        }
+
+        It 'warns when no range changes are requested' {
+            Mock Write-Warning
+
+            Set-InfobloxDHCPRange -ReferenceID 'range/reference'
+
+            Should -Invoke -CommandName Write-Warning -Times 1 -ParameterFilter {
+                $Message -eq 'Set-InfobloxDHCPRange - No changes requested'
+            }
+            Should -Invoke -CommandName Invoke-InfobloxQuery -Times 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add explicit DHCP range DDNS inheritance controls with `-DDNSUpdateMode Inherit|Override`
- add `-DDNSEnabled $true|$false` for local DDNS enablement; supplying it selects override mode
- keep `-AlwaysUpdateDns` backward compatible and document that it controls update policy, not DDNS enablement
- clear blank/false comments on updates and omit them on creates without breaking normal PowerShell string coercion
- add focused regression coverage for create/update payloads and invalid DDNS combinations

## Usage

```powershell
# Override the inherited setting and disable DDNS for this range
Set-InfobloxDHCPRange -ReferenceID $RangeRef -DDNSUpdateMode Override -DDNSEnabled $false

# Return to the parent/grid setting
Set-InfobloxDHCPRange -ReferenceID $RangeRef -DDNSUpdateMode Inherit

# Clear a comment
Set-InfobloxDHCPRange -ReferenceID $RangeRef -Comment ''
```

## Validation

- PowerShell 7.6.4 / Pester 5.7.1: 29 passed
- Windows PowerShell 5.1 / Pester 5.8.0: 29 passed
- PSPublishModule manifest gate completed successfully
- changed files parse cleanly with no new PSScriptAnalyzer warnings
- independent local review completed; one compatibility finding was fixed and confirmed