### PR TITLE
Fix Microsoft DHCP server serialization

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+### Unreleased
+- Send Microsoft DHCP server associations as WAPI `msdhcpserver` structures in JSON request bodies
+- Create DHCP reservations through the NIOS `fixedaddress` object endpoint
+
 ### 1.0.38 - 2026.07.29
 - Add explicit inherit/override and enabled/disabled controls for DHCP range DDNS updates
 - Keep the existing `AlwaysUpdateDns` policy separate from DDNS enablement

--- a/Private/ConvertTo-InfobloxMicrosoftDHCPServer.ps1
+++ b/Private/ConvertTo-InfobloxMicrosoftDHCPServer.ps1
@@ -1,0 +1,20 @@
+function ConvertTo-InfobloxMicrosoftDHCPServer {
+    <#
+    .SYNOPSIS
+    Converts a Microsoft DHCP server address to the WAPI msdhcpserver structure.
+
+    .PARAMETER MicrosoftServer
+    IPv4 address or FQDN of a Microsoft DHCP server known to Infoblox.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string] $MicrosoftServer
+    )
+
+    [pscustomobject] @{
+        _struct  = 'msdhcpserver'
+        ipv4addr = $MicrosoftServer
+    }
+}

--- a/Public/Add-InfobloxDHCPRange.ps1
+++ b/Public/Add-InfobloxDHCPRange.ps1
@@ -22,7 +22,7 @@
     The network view in which the DHCP range will be added. The default is 'default'.
 
     .PARAMETER MSServer
-    The Microsoft server to which the DHCP range will be added.
+    The IPv4 address or FQDN of the Microsoft DHCP server to which the range will be added.
 
     .PARAMETER ReturnOutput
     If this switch is present, the function will return the output of the operation.
@@ -160,10 +160,7 @@
         $Body["server_association_type"] = $ServerAssociationType
     }
     if ($MSServer) {
-        $Body["ms_server"] = [PSCustomObject] @{
-            "_struct"  = "msdhcpserver"
-            "ipv4addr" = $MSServer
-        }
+        $Body["ms_server"] = ConvertTo-InfobloxMicrosoftDHCPServer -MicrosoftServer $MSServer
     }
     if ($ExtensinbleAttribute) {
         $Body["extattrs"] = ConvertTo-InfobloxExtattrs -Attributes $ExtensinbleAttribute

--- a/Public/Add-InfobloxDHCPReservation.ps1
+++ b/Public/Add-InfobloxDHCPReservation.ps1
@@ -22,7 +22,7 @@
     Subnet to add the reservation to
 
     .PARAMETER MicrosoftServer
-    Microsoft server to use for the fixed address
+    IPv4 address or FQDN of the Microsoft DHCP server to use for the reservation.
 
     .EXAMPLE
     Add-InfobloxDHCPReservation -IPv4Address '10.2.2.18' -MacAddress '00:50:56:9A:00:01' -Name 'MyReservation' -Network '10.2.2.0/24' -Comment 'This is a test reservation' -MicrosoftServer 'myserver'
@@ -47,23 +47,24 @@
         return
     }
 
-    $invokeInfobloxQuerySplat = @{
-        RelativeUri    = 'record:dhcpreservation'
-        Method         = 'POST'
-        QueryParameter = @{
-            ipv4addr = $IPv4Address
-            mac      = $MacAddress.ToLower()
-            network  = $Network
-        }
+    $Body = [ordered] @{
+        ipv4addr = $IPv4Address
+        mac      = $MacAddress.ToLower()
+        network  = $Network
     }
     if ($Name) {
-        $invokeInfobloxQuerySplat.QueryParameter.name = $Name
+        $Body['name'] = $Name
     }
     if ($Comment) {
-        $invokeInfobloxQuerySplat.QueryParameter.comment = $Comment
+        $Body['comment'] = $Comment
     }
     if ($MicrosoftServer) {
-        $invokeInfobloxQuerySplat.QueryParameter.ms_server = $MicrosoftServer
+        $Body['ms_server'] = ConvertTo-InfobloxMicrosoftDHCPServer -MicrosoftServer $MicrosoftServer
+    }
+    $invokeInfobloxQuerySplat = @{
+        RelativeUri = 'fixedaddress'
+        Method      = 'POST'
+        Body        = $Body
     }
     $Output = Invoke-InfobloxQuery @invokeInfobloxQuerySplat
     if ($Output) {

--- a/Public/Add-InfobloxFixedAddress.ps1
+++ b/Public/Add-InfobloxFixedAddress.ps1
@@ -22,7 +22,7 @@
     Comment for the fixed address
 
     .PARAMETER MicrosoftServer
-    Microsoft server to use for the fixed address
+    IPv4 address or FQDN of the Microsoft DHCP server to use for the fixed address.
 
     .EXAMPLE
     Add-InfobloxFixedAddress -IPv4Address '10.2.2.18' -MacAddress '00:50:56:9A:00:01'
@@ -49,22 +49,23 @@
 
     Write-Verbose -Message "Add-InfobloxFixedAddress - Adding IPv4Address $IPv4Address to MacAddress $MacAddress"
 
-    $invokeInfobloxQuerySplat = @{
-        RelativeUri    = 'fixedaddress'
-        Method         = 'POST'
-        QueryParameter = @{
-            ipv4addr = $IPv4Address
-            mac      = $MacAddress.ToLower()
-        }
+    $Body = [ordered] @{
+        ipv4addr = $IPv4Address
+        mac      = $MacAddress.ToLower()
     }
     if ($Name) {
-        $invokeInfobloxQuerySplat.QueryParameter.name = $Name
+        $Body['name'] = $Name
     }
     if ($Comment) {
-        $invokeInfobloxQuerySplat.QueryParameter.comment = $Comment
+        $Body['comment'] = $Comment
     }
     if ($MicrosoftServer) {
-        $invokeInfobloxQuerySplat.QueryParameter.ms_server = $MicrosoftServer
+        $Body['ms_server'] = ConvertTo-InfobloxMicrosoftDHCPServer -MicrosoftServer $MicrosoftServer
+    }
+    $invokeInfobloxQuerySplat = @{
+        RelativeUri = 'fixedaddress'
+        Method      = 'POST'
+        Body        = $Body
     }
     $Output = Invoke-InfobloxQuery @invokeInfobloxQuerySplat #-WarningAction SilentlyContinue -WarningVariable varWarning
     if ($Output) {

--- a/Public/Set-InfobloxDHCPRange.ps1
+++ b/Public/Set-InfobloxDHCPRange.ps1
@@ -13,7 +13,7 @@
     A comment to associate with the DHCP range. Pass an empty, null, or Boolean false value to clear the comment.
 
     .PARAMETER MSServer
-    The Microsoft DHCP server associated with the range.
+    The IPv4 address or FQDN of the Microsoft DHCP server associated with the range.
 
     .PARAMETER ExtensinbleAttribute
     A hashtable of extensible attributes to associate with the DHCP range.
@@ -100,10 +100,7 @@
         $Body["server_association_type"] = $ServerAssociationType
     }
     if ($MSServer) {
-        $Body["ms_server"] = [PSCustomObject] @{
-            "_struct"  = "msdhcpserver"
-            "ipv4addr" = $MSServer
-        }
+        $Body["ms_server"] = ConvertTo-InfobloxMicrosoftDHCPServer -MicrosoftServer $MSServer
     }
     if ($ExtensinbleAttribute) {
         $Body["extattrs"] = ConvertTo-InfobloxExtattrs -Attributes $ExtensinbleAttribute

--- a/Tests/DHCPRange.Tests.ps1
+++ b/Tests/DHCPRange.Tests.ps1
@@ -79,6 +79,20 @@ Describe 'DHCP range mutations' {
             $script:requestBody.Contains('use_enable_ddns') | Should -BeFalse
         }
 
+        It 'maps a Microsoft server through the shared WAPI structure when creating a range' {
+            Add-InfobloxDHCPRange -StartAddress '192.0.2.10' -EndAddress '192.0.2.20' -MSServer 'ms-dhcp.example.test'
+
+            $script:requestBody.ms_server._struct | Should -Be 'msdhcpserver'
+            $script:requestBody.ms_server.ipv4addr | Should -Be 'ms-dhcp.example.test'
+        }
+
+        It 'maps a Microsoft server through the shared WAPI structure when updating a range' {
+            Set-InfobloxDHCPRange -ReferenceID 'range/reference' -MSServer 'ms-dhcp.example.test'
+
+            $script:requestBody.ms_server._struct | Should -Be 'msdhcpserver'
+            $script:requestBody.ms_server.ipv4addr | Should -Be 'ms-dhcp.example.test'
+        }
+
         It 'warns when no range changes are requested' {
             Mock Write-Warning
 

--- a/Tests/FixedAddress.Tests.ps1
+++ b/Tests/FixedAddress.Tests.ps1
@@ -1,0 +1,60 @@
+Describe 'Microsoft DHCP fixed address mutations' {
+    InModuleScope PowerInfoblox {
+        BeforeAll {
+            $script:previousDefaults = @{}
+            foreach ($Key in $PSDefaultParameterValues.Keys) {
+                $script:previousDefaults[$Key] = $PSDefaultParameterValues[$Key]
+            }
+        }
+
+        BeforeEach {
+            $Script:InfobloxConfiguration = @{ BaseUri = 'https://grid.example.test/wapi/v2.9' }
+            $PSDefaultParameterValues['Invoke-InfobloxQuery:BaseUri'] = 'https://grid.example.test/wapi/v2.9'
+            $PSDefaultParameterValues['Invoke-InfobloxQuery:Credential'] = [pscredential]::new('user', [System.Security.SecureString]::new())
+            Mock Invoke-RestMethod -MockWith { 'fixedaddress/reference' }
+        }
+
+        AfterAll {
+            $Script:InfobloxConfiguration = $null
+            $PSDefaultParameterValues.Clear()
+            foreach ($Key in $script:previousDefaults.Keys) {
+                $PSDefaultParameterValues[$Key] = $script:previousDefaults[$Key]
+            }
+        }
+
+        It 'sends a fixed address and Microsoft server structure in the JSON body' {
+            Add-InfobloxFixedAddress -IPv4Address '192.0.2.151' -MacAddress '02:00:5E:10:00:01' -Name 'test reservation' -Comment 'test reservation' -MicrosoftServer 'ms-dhcp.example.test'
+
+            Should -Invoke -CommandName Invoke-RestMethod -Times 1 -ParameterFilter {
+                if ($Uri -ne 'https://grid.example.test/wapi/v2.9/fixedaddress' -or $Method -ne 'POST') {
+                    return $false
+                }
+                $Payload = $Body | ConvertFrom-Json
+                $Payload.ipv4addr -eq '192.0.2.151' -and
+                $Payload.mac -eq '02:00:5e:10:00:01' -and
+                $Payload.name -eq 'test reservation' -and
+                $Payload.comment -eq 'test reservation' -and
+                $Payload.ms_server._struct -eq 'msdhcpserver' -and
+                $Payload.ms_server.ipv4addr -eq 'ms-dhcp.example.test'
+            }
+        }
+
+        It 'sends a DHCP reservation and Microsoft server structure in the JSON body' {
+            Add-InfobloxDHCPReservation -IPv4Address '192.0.2.152' -MacAddress '02:00:5E:10:00:02' -Name 'test reservation' -Network '192.0.2.0/24' -Comment 'test reservation' -MicrosoftServer 'ms-dhcp.example.test'
+
+            Should -Invoke -CommandName Invoke-RestMethod -Times 1 -ParameterFilter {
+                if ($Uri -ne 'https://grid.example.test/wapi/v2.9/fixedaddress' -or $Method -ne 'POST') {
+                    return $false
+                }
+                $Payload = $Body | ConvertFrom-Json
+                $Payload.ipv4addr -eq '192.0.2.152' -and
+                $Payload.mac -eq '02:00:5e:10:00:02' -and
+                $Payload.network -eq '192.0.2.0/24' -and
+                $Payload.name -eq 'test reservation' -and
+                $Payload.comment -eq 'test reservation' -and
+                $Payload.ms_server._struct -eq 'msdhcpserver' -and
+                $Payload.ms_server.ipv4addr -eq 'ms-dhcp.example.test'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- send fixed-address and DHCP-reservation creation data as JSON request bodies
- serialize Microsoft DHCP server associations as WAPI `msdhcpserver` structures through one shared helper
- use the NIOS `fixedaddress` endpoint for IPv4 DHCP reservations
- reuse and verify the same Microsoft-server mapping for DHCP range create and update operations

## Validation
- PowerShell 7: 33 Pester tests passed
- Windows PowerShell 5.1: 33 Pester tests passed
- PSScriptAnalyzer passed for changed PowerShell files
- PSPublishModule Manifest gate passed with signing disabled
- independent local review completed with no P0-P3 findings